### PR TITLE
Configure Vercel deployment for Python API

### DIFF
--- a/user_models.py
+++ b/user_models.py
@@ -1,5 +1,11 @@
-"""Occupancy model helpers kept for backwards compatibility."""
+"""Backwards compatibility facade exposing the public user models."""
 
+from monkapp.building import BuildingParameters, BuildingThermalModel
 from monkapp.occupancy import OccupancyModel, build_profile_from_periods
 
-__all__ = ["OccupancyModel", "build_profile_from_periods"]
+__all__ = [
+    "BuildingParameters",
+    "BuildingThermalModel",
+    "OccupancyModel",
+    "build_profile_from_periods",
+]

--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,14 @@
 {
     "version": 2,
-    "builds": [
-        {
-            "src": "api/index.php",
-            "use": "vercel-php@0.6.0"
+    "functions": {
+        "api/**/*.py": {
+            "runtime": "python3.10"
         }
-    ],
+    },
     "rewrites": [
         {
-            "source": "/(.*)",
-            "destination": "/api/index.php"
+            "source": "/",
+            "destination": "/api/simulate"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- expose the building model types through user_models so the API can use the detailed simulator
- update the Vercel configuration to target the Python runtime and rewrite the root path to the simulation endpoint

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c893cd3c508329aed74fee75065b9f