### PR TITLE
Fix Vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
     "version": 2,
     "functions": {
         "api/**/*.py": {
-            "runtime": "python3.10"
+            "runtime": "vercel-python@0.5.4"
         }
     },
     "rewrites": [


### PR DESCRIPTION
## Summary
- update the Vercel function runtime to use a valid Python runtime version string

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89507a9a883298a7fde8cf297d8ce